### PR TITLE
Use Array.reduce, add edge test cases

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -13,20 +13,19 @@ export default function getNestedProperty (data = window, path = '') {
 
   if (typeof path === 'string') {
 
-    let result = data;
-
-    if (path !== '') {
-      path.split('.').forEach(function (segment) {
-        result = (
-          typeof result !== 'undefined' &&
-          typeof result[segment] !== 'undefined'
+    return path
+      .split('.')
+      .filter(function(segment) {
+        return segment.length > 0
+      })
+      .reduce(function(parent, segment) {
+        return (
+          typeof parent !== 'undefined' &&
+          typeof parent[segment] !== 'undefined'
         )
-          ? result[segment]
-          : undefined;
-      });
-    }
-
-    return result;
+          ? parent[segment]
+          : undefined
+      }, data)
 
   } else {
 

--- a/test/index.spec.js
+++ b/test/index.spec.js
@@ -45,6 +45,21 @@ describe('getNestedProperty', function () {
     expect(getNestedProperty(data)).toEqual(data);
   });
 
+  it('should handle multiple consecutive dots as one', function () {
+    const data = {aaa: {bbb: 'ccc'}};
+    expect(getNestedProperty(data, 'aaa...bbb')).toEqual('ccc');
+  });
+
+  it('should ignore leading dot', function () {
+    const data = {aaa: 'bbb'};
+    expect(getNestedProperty(data, '.aaa')).toEqual('bbb');
+  });
+
+  it('should ignore trailing dot', function () {
+    const data = {aaa: 'bbb'};
+    expect(getNestedProperty(data, 'aaa.')).toEqual('bbb');
+  });
+
   it('should throw an error if path is not a string', function () {
     const fn = function () {getNestedProperty({}, [])};
     expect(fn).toThrow();


### PR DESCRIPTION
`Array.reduce` seems to be cleaner when computing single value from an Array.

Using `filter` to filter empty path segments allows path to be less error-prone. For this cases there are new tests.
